### PR TITLE
fix: create files for os_distro == AlmaLinux

### DIFF
--- a/tasks/configure-AlmaLinux.yml
+++ b/tasks/configure-AlmaLinux.yml
@@ -1,0 +1,11 @@
+---
+- name: Configure IPoIB interfaces
+  ansible.builtin.template:
+    src: ifcfg-ib.j2
+    dest: /etc/sysconfig/network-scripts/ifcfg-{{ item.iface }}
+  loop: "{{ mlnx_ofed_ipoib_interfaces }}"
+  loop_control:
+    index_var: idx
+    label: "Configure {{ item.iface }}"
+  notify: Restart interface
+  register: configure_ipoib

--- a/tasks/install-AlmaLinux.yml
+++ b/tasks/install-AlmaLinux.yml
@@ -1,0 +1,6 @@
+---
+- name: Install MLNX_OFED packages for AlmaLinux OS family
+  ansible.builtin.package:
+    name:
+     - kmod-mlnx-ofa_kernel
+  notify: "Ensure openibd.service is started"

--- a/tasks/repositories-AlmaLinux.yml
+++ b/tasks/repositories-AlmaLinux.yml
@@ -1,0 +1,14 @@
+---
+- name: Install Mellanox GPG-KEY
+  ansible.builtin.rpm_key:
+    key: "{{ mlnx_ofed_gpg_key }}"
+    state: present
+
+- name: Configure MLNX_OFED repository
+  ansible.builtin.yum_repository:
+    name: mlnx_ofed
+    baseurl: "{{ mlnx_ofed_yum_repository }}"
+    description: "MLNX_OFED"
+    enabled: True
+    gpgcheck: True
+    gpgkey: "{{ mlnx_ofed_gpg_key }}"


### PR DESCRIPTION
There is a bug with Ansible < 2.9.20 where the `os_distro` for AlmaLinux
is AlmaLinux instead of RedHat. Add new files to include in main.yml for
environments still running an old Ansible 2.9 version but shifting from
CentOS to AlmaLinux.