### PR TITLE
Add support of SR-IOV

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,10 +24,10 @@ infiniband_gpg_key: 'http://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox
 # print(f"offset: -{offset}")
 # EOF
 #
-infiniband_ipoib_interfaces:
-  - iface: 'ib0'
-    offset: -3064461568
-    prefix: 17
+# infiniband_ipoib_interfaces:
+#   - iface: 'ib0'
+#     offset: -3064461568
+#     prefix: 17
 
 # Name of the kernel headers package
 infiniband_kernel_headers_package: 'linux-headers'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,3 +40,13 @@ infiniband_kernel_headers_package: 'linux-headers'
 # such cases, the parameters below can be set to False in the host inventory.
 infiniband_configure_repos: True
 infiniband_install_kernel_modules: True
+
+# Configure Mellanox HCAs
+# The pci_bus must match the value in /sys/bus/pci/devices/
+# e.g. /sys/bus/pci/devices/0000:41:00.0/
+#
+# infiniband_hca_devices:
+#   - device: mlx5_0
+#     pci_bus: '0000:41:00.0'
+#     sriov_en: True
+#     num_of_vfs: 8

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,3 +50,19 @@ infiniband_install_kernel_modules: True
 #     pci_bus: '0000:41:00.0'
 #     sriov_en: True
 #     num_of_vfs: 8
+
+# Define the prefix to use for the 64-bits IB GUID of VFs
+# The role will define the GUID with:
+#  - prefix (40 bits)
+#  - "00" (8 bits)
+#  - device ID (8 bits): item index in list infiniband_hca_devices above
+#  - VF ID (8 bits): index of VF in range(infiniband_hca_devices[*].num_of_vfs)
+#
+# It is highly recommended to define a value different than the default if you
+# plan to configure more than one host with SR-IOV in your IB fabric.
+#
+# To allow failover in high availability configuration, make sure to use the
+# same infiniband_hca_devices and infiniband_guid_prefix for all hosts where a
+# given VM could run.
+#
+infiniband_guid_prefix: "4d:69:6c:61:00"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -15,3 +15,8 @@
   throttle: 1
   ansible.builtin.reboot:
     msg: "Infiniband: Reboot machine to load new configurations."
+
+- name: Restart sysfsutils
+  ansible.builtin.systemd:
+    name: sysfsutils.service
+    state: restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,3 +10,8 @@
   ansible.builtin.systemd:
     name: openibd.service
     state: started
+
+- name: Reboot to load new configurations
+  throttle: 1
+  ansible.builtin.reboot:
+    msg: "Infiniband: Reboot machine to load new configurations."

--- a/tasks/configure_hca-Debian.yml
+++ b/tasks/configure_hca-Debian.yml
@@ -1,0 +1,17 @@
+---
+- name: Query current configuration of the IB device(s)
+  ansible.utils.cli_parse:
+    command: mstconfig query
+    parser:
+      name: ansible.netcommon.native
+    set_fact: mstconfig_query
+
+- name: Configure the IB device(s)
+  ansible.builtin.command: >
+    mstconfig -d {{ item.pci_bus }} --yes set
+      SRIOV_EN={{ item.sriov_en | bool }}
+      NUM_OF_VFS={{ item.num_of_vfs | int }}
+  loop: "{{ infiniband_hca_devices }}"
+  when: (mstconfig_query[item.pci_bus].sriov_en | bool != item.sriov_en | bool) or
+        (mstconfig_query[item.pci_bus].num_of_vfs | int != item.num_of_vfs | int)
+  notify: Reboot to load new configurations

--- a/tasks/configure_sriov-Debian.yml
+++ b/tasks/configure_sriov-Debian.yml
@@ -1,0 +1,20 @@
+---
+- name: Install sysfsutils
+  ansible.builtin.package:
+    name:
+      - sysfsutils
+
+- name: Enable sysfsutils
+  ansible.builtin.systemd:
+    name: sysfsutils
+    enabled: True
+
+- name: Configure sriov_numvfs
+  ansible.builtin.template:
+    src: sysfs_sriov.j2
+    dest: "/etc/sysfs.d/{{ item.device }}_sriov.conf"
+  loop: "{{ infiniband_hca_devices }}"
+  loop_control:
+    index_var: devid
+  when: item.sriov_en
+  notify: Restart sysfsutils

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,3 +20,4 @@
 - name: Configure IPoIB interfaces
   ansible.builtin.include_tasks:
     file: "configure-{{ ansible_facts['os_family'] }}.yml"
+  when: infiniband_ipoib_interfaces is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,12 @@
 - name: Flush handlers
   meta: flush_handlers
 
+  # Include only when at least one item has 'sriov_en: True'
+- name: Configure SR-IOV
+  ansible.builtin.include_tasks:
+    file: "configure_sriov-{{ ansible_facts['os_family'] }}.yml"
+  when: (infiniband_hca_devices | map(attribute='sriov_en') | list) is any
+
 - name: Configure IPoIB interfaces
   ansible.builtin.include_tasks:
     file: "configure-{{ ansible_facts['os_family'] }}.yml"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,12 @@
   ansible.builtin.package:
     name:
       - infiniband-diags
+      - mstflint
+
+- name: Configure Mellanox HCAs
+  ansible.builtin.include_tasks:
+    file: "configure_hca-{{ ansible_facts['os_family'] }}.yml"
+  when: infiniband_hca_devices is defined
 
 - name: Flush handlers
   meta: flush_handlers

--- a/templates/debian_mstconfig_query.yaml
+++ b/templates/debian_mstconfig_query.yaml
@@ -1,0 +1,24 @@
+---
+# Template used to parse output of 'mstconfig query' with the cli_parse module.
+
+# Get the PCI bus of the device(s)
+- example: 'Device:         /sys/bus/pci/devices/0000:41:00.0/config'
+  getval: 'Device:\s+\/sys\/bus\/pci\/devices\/(?P<pci>\S+)\/'
+  result:
+    "{{ pci }}":
+        pci_bus: "{{ pci }}"
+  shared: True
+
+# Get number of VFs
+- example: '         NUM_OF_VFS                          16'
+  getval: '\s+NUM_OF_VFS\s+(?P<value>\S+)'
+  result:
+    "{{ pci }}":
+        num_of_vfs: "{{ value }}"
+
+# Get SR-IOV status
+- example: '         SRIOV_EN                            True(1)'
+  getval: '\s+SRIOV_EN\s+(?P<value>\S+)\([01]\)'
+  result:
+    "{{ pci }}":
+        sriov_en: "{{ value }}"

--- a/templates/sysfs_sriov.j2
+++ b/templates/sysfs_sriov.j2
@@ -1,0 +1,17 @@
+#jinja2: lstrip_blocks: True
+# Ansible managed
+class/infiniband/{{ item.device }}/device/sriov_numvfs = {{ item.num_of_vfs }}
+{% for vfid in range(item.num_of_vfs) %}
+{# The VF GUID is the combination of:
+ - a global prefix
+ - the device ID
+ - the VF ID.
+#}
+{% set vfguid = infiniband_guid_prefix ~ ":00:" ~ ('%02x' | format(devid)) ~
+    ":" ~ ('%02x' | format(vfid)) %}
+class/infiniband/{{ item.device }}/device/sriov/{{ vfid }}/node = {{ vfguid }}
+class/infiniband/{{ item.device }}/device/sriov/{{ vfid }}/port = {{ vfguid }}
+  {% if item.policy is defined %}
+class/infiniband/{{ item.device }}/device/sriov/{{ vfid }}/policy = {{ item.policy }}
+  {% endif %}
+{% endfor %}


### PR DESCRIPTION
With this change, the role can configure the parameters SRIOV_EN and NUM_OF_VFS in the Mellanox HCAs. It relies on the command `mstconfig` and the PCI address of the devices to define the parameters. These must be defined in the inventory with the optional variable `infiniband_hca_devices`. An example is provided in the defaults.

If the variable is not defined, the role will skip the configuration of the HCA.

A reboot is mandatory after a configuration change on the HCA. A new handler will reboot the host if requested. Since SR-IOV is mostly used for hypervisors, make sure to serialize the reboots with `throttle: 1`. This will allow to reboot the hosts one after the other, with limited impact on services hosted in virtualization clusters.

It is usually possible to create up to NUM_OF_VFS in the kernel by writing the requested number of VFs in the `sriov_numvfs` Linux kernel file. In order to ease the configuration, this role will set `sriov_numvfs = NUM_OF_VFS`, so the maximum of VFs will be created. If one needs less VFs, they will have to lower NUM_OF_VFS as well. The is configurable with  `infiniband_hca_devices[*].num_of_vfs` in the inventory.

Install the sysfsutils package and write the sysfs configuration file to make the configuration persistent on reboot.

Define the VF GUID from a prefix + device ID + VF ID.