### PR TITLE
fix: Use filters from ansible.utils collection

### DIFF
--- a/templates/ib.cfg.j2
+++ b/templates/ib.cfg.j2
@@ -5,11 +5,11 @@
 3. Validate the host/prefix with ipv4 filter
 #}
 {% set ipoib_host = (ansible_facts['default_ipv4'].address |
-    ansible.netcommon.ipmath(item.offset) + '/' + item.prefix | string) |
-    ansible.netcommon.ipv4('host/prefix') -%}
+    ansible.utils.ipmath(item.offset) + '/' + item.prefix | string) |
+    ansible.utils.ipv4('host/prefix') -%}
 auto {{ item.iface }}
 iface {{ item.iface }} inet static
-  address   {{ ipoib_host | ansible.netcommon.ipaddr('address') }}
-  network   {{ ipoib_host | ansible.netcommon.ipaddr('network') }}
-  netmask   {{ ipoib_host | ansible.netcommon.ipaddr('netmask') }}
-  broadcast {{ ipoib_host | ansible.netcommon.ipaddr('broadcast') }}
+  address   {{ ipoib_host | ansible.utils.ipaddr('address') }}
+  network   {{ ipoib_host | ansible.utils.ipaddr('network') }}
+  netmask   {{ ipoib_host | ansible.utils.ipaddr('netmask') }}
+  broadcast {{ ipoib_host | ansible.utils.ipaddr('broadcast') }}

--- a/templates/ifcfg-ib.j2
+++ b/templates/ifcfg-ib.j2
@@ -5,15 +5,15 @@
 3. Validate the host/prefix with ipv4 filter
 #}
 {% set ipoib_host = (ansible_facts['default_ipv4'].address |
-    ansible.netcommon.ipmath(item.offset) + '/' + item.prefix | string) |
-    ansible.netcommon.ipv4('host/prefix') -%}
+    ansible.utils.ipmath(item.offset) + '/' + item.prefix | string) |
+    ansible.utils.ipv4('host/prefix') -%}
 DEVICE={{ item.iface }}
 NAME={{ item.iface }}
 TYPE=InfiniBand
-IPADDR={{ ipoib_host | ansible.netcommon.ipaddr('address') }}
-NETMASK={{ ipoib_host | ansible.netcommon.ipaddr('netmask') }}
-NETWORK={{ ipoib_host | ansible.netcommon.ipaddr('network') }}
-BROADCAST={{ ipoib_host | ansible.netcommon.ipaddr('broadcast') }}
+IPADDR={{ ipoib_host | ansible.utils.ipaddr('address') }}
+NETMASK={{ ipoib_host | ansible.utils.ipaddr('netmask') }}
+NETWORK={{ ipoib_host | ansible.utils.ipaddr('network') }}
+BROADCAST={{ ipoib_host | ansible.utils.ipaddr('broadcast') }}
 BOOTPROTO=static
 ONBOOT=yes
 IPV4_FAILURE_FATAL=yes


### PR DESCRIPTION
The filters ipaddr, ipmath and ipv4 migrated from ansible.netcommon to ansible.utils. Update the code accordingly.