### PR TITLE
fix: Use Debian cli_parse template for Ubuntu

### DIFF
--- a/templates/ubuntu_mstconfig_query.yaml
+++ b/templates/ubuntu_mstconfig_query.yaml
@@ -1,0 +1,1 @@
+debian_mstconfig_query.yaml


### PR DESCRIPTION
Allow to configure the InfiniBand HCAs with Ubuntu OS. The output of the `mstconfig query` command should be similar for both Debian and Ubuntu, thus we can safely use a symlink.