### PR TITLE
fix: Do not force reboot to load new HCA configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ could run.
 
     infiniband_guid_prefix: "4d:69:6c:61:00"
 
+By default, the role will reboot the hosts to load any new configuration. It is
+possible to forbid the reboot with:
+
+    infiniband_allow_reboot: false
+
+To avoid any unexpected downtime in high availability clusters, the role will
+reboot the hosts one after the other. It is possible to increase the throttle
+with:
+
+    infiniband_throttle_reboot: "{{ ansible_play_hosts | length }}"
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,6 +54,13 @@ infiniband_install_kernel_modules: True
 #     sriov_en: True
 #     num_of_vfs: 8
 
+# Allow host reboot to load new configurations
+# If disabled, one will have to reboot later to load any new configuration
+infiniband_allow_reboot: True
+
+# Reboot the hosts one after the other
+infiniband_throttle_reboot: 1
+
 # Define the prefix to use for the 64-bits IB GUID of VFs
 # The role will define the GUID with:
 #  - prefix (40 bits)

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -17,9 +17,10 @@
     state: restarted
 
 - name: Reboot to load new configurations
-  throttle: 1
+  throttle: "{{ infiniband_throttle_reboot }}"
   ansible.builtin.reboot:
     msg: "Infiniband: Reboot machine to load new configurations."
+  when: infiniband_allow_reboot
 
 - name: Restart sysfsutils
   ansible.builtin.systemd:


### PR DESCRIPTION
In some cases, one may want to apply a new configuration to an HCA without rebooting the host. Add a new variable `infiniband_allow_reboot` that permits to disable the reboot that should occur after an HCA configuration change.

Also allow to increase the default throttle of 1 with `infiniband_throttle_reboot`.