### PR TITLE
fix: Allow to unload irdma with openibd

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -82,3 +82,6 @@ infiniband_guid_prefix: "4d:69:6c:61:00"
 # This parameter only has effect on RHEl-like OS. If set to False, the IPoIB
 # interfaces will default to Connected mode.
 infiniband_ipoib_enhanced: True
+
+# Apply patches on installed files
+infiniband_patch: false

--- a/files/openibd_unload_irdma.patch
+++ b/files/openibd_unload_irdma.patch
@@ -1,0 +1,11 @@
+--- a/openibd	2012-12-31 13:38:53.000000000 +0000
++++ b/openibd	2023-12-20 01:59:51.479600161 +0000
+@@ -361,7 +361,7 @@
+ UNLOAD_MODULES="$UNLOAD_MODULES ib_qib"
+ UNLOAD_MODULES="$UNLOAD_MODULES eth_ipoib ib_ipoib mlx4_vnic ib_madeye ib_rds hns_roce"
+ UNLOAD_MODULES="$UNLOAD_MODULES rds_rdma rds_tcp rds ib_ucm kdapl ib_srp_target scsi_target ib_srp ib_iser ib_sdp"
+-UNLOAD_MODULES="$UNLOAD_MODULES rdma_ucm rdma_cm iw_cm ib_cm ib_local_sa findex"
++UNLOAD_MODULES="$UNLOAD_MODULES rdma_ucm rdma_cm iw_cm ib_cm ib_local_sa findex irdma"
+ UNLOAD_MODULES="$UNLOAD_MODULES auxiliary mlxdevm mlx5_vdpa"
+ UNLOAD_MODULES="$UNLOAD_MODULES ib_sa ib_uverbs ib_umad ib_mad ib_core ib_addr ib_netlink rdma_rxe mlxfw vfio_mdev"
+ 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,11 @@
       - mstflint
       - perftest
 
+- name: Apply patches
+  ansible.builtin.include_tasks:
+    file: patch.yml
+  when: infiniband_patch
+
 - name: Configure Mellanox HCAs
   ansible.builtin.include_tasks:
     file: "configure_hca-{{ ansible_facts['os_family'] }}.yml"

--- a/tasks/patch.yml
+++ b/tasks/patch.yml
@@ -1,0 +1,14 @@
+---
+- name: Ensure patch is installed
+  ansible.builtin.package:
+    name: patch
+
+- name: Patch openibd.service to unload irdma
+  ansible.posix.patch:
+    src: 'openibd_unload_irdma.patch'
+    basedir: '/etc/init.d'
+    strip: 1
+  when:
+    - infiniband_patch_irdma is defined
+    - infiniband_patch_irdma
+


### PR DESCRIPTION
It might happen that the in-kernel module ib_uverbs is in use by the in-kernel module irdma on servers with Ethernet interfaces that support RDMA. In order to reload the MLNX_OFED modules after the installation, openibd must unload the module irdma.

Add a mechanism which allows to apply known patches on demand with the role.