### PR TITLE
feat: Allow to upgrade packages to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Define the APT or YUM/DNF repositories, with the path to the GPG key.
     # Mellanox GPG Key
     infiniband_gpg_key: 'http://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox'
 
+To upgrade the packages to the latest version available.
+
+    infiniband_upgrade: True
+
 To pin the priority of the repository (APT only).
 
     infiniband_apt_priority: 490

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,9 @@ infiniband_yum_repository: 'https://linux.mellanox.com/public/repo/mlnx_ofed/lat
 # Mellanox GPG Key
 infiniband_gpg_key: 'http://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox'
 
+# Set to True to upgrade packages to the latest version available
+infiniband_upgrade: False
+
 # Pin the priority of the APT repository.
 # infiniband_apt_priority: 490
 

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -5,6 +5,7 @@
       - mlnx-ofed-kernel-dkms
       - mlnx-ofed-kernel-utils
       - "{{ infiniband_kernel_headers_package }}-{{ ansible_facts['kernel'] }}"
+    state: "{{ 'latest' if infiniband_upgrade else 'present' }}"
   register: packages_install
   notify: "Ensure openibd.service is started"
 

--- a/tasks/install-RedHat.yml
+++ b/tasks/install-RedHat.yml
@@ -4,4 +4,5 @@
     name:
       - mlnx-ofa_kernel-devel
       - kmod-mlnx-ofa_kernel
+    state: "{{ 'latest' if infiniband_upgrade else 'present' }}"
   notify: "Ensure openibd.service is started"


### PR DESCRIPTION
Set `infiniband_upgrade: True` to upgrade the packages to the latest version available. Defaults to `False`.