### PR TITLE
feat: Install mlnx-ofed-basic by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,11 @@ infiniband_upgrade: False
 # Name of the kernel headers package
 infiniband_kernel_headers_package: 'linux-headers'
 
+# Flavor of mlnx-ofed-* to install.
+# Values can be `basic`, `all`, `hpc`, etc.
+# See NVIDIA MLNX_OFED documentation for a complete list of flavors.
+infiniband_mlnx_ofed_flavor: 'basic'
+
 # Default to configure the repos and install the kernel modules.
 #
 # Some appliances like the NVIDIA DGX run their own software stack. When an

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -2,8 +2,7 @@
 - name: Install MLNX_OFED packages for Debian OS family
   ansible.builtin.package:
     name:
-      - mlnx-ofed-kernel-dkms
-      - mlnx-ofed-kernel-utils
+      - "mlnx-ofed-{{ infiniband_mlnx_ofed_flavor }}"
       - "{{ infiniband_kernel_headers_package }}-{{ ansible_facts['kernel'] }}"
     state: "{{ 'latest' if infiniband_upgrade else 'present' }}"
   register: packages_install

--- a/tasks/install-RedHat.yml
+++ b/tasks/install-RedHat.yml
@@ -2,7 +2,6 @@
 - name: Install MLNX_OFED packages for Red Hat OS family
   ansible.builtin.package:
     name:
-      - mlnx-ofa_kernel-devel
-      - kmod-mlnx-ofa_kernel
+      - "mlnx-ofed-{{ infiniband_mlnx_ofed_flavor }}"
     state: "{{ 'latest' if infiniband_upgrade else 'present' }}"
   notify: "Ensure openibd.service is started"


### PR DESCRIPTION
NVIDIA MLNX_OFED offers several package groups (flavors) to install. Install the mlnx-ofed-basic which includes the kernel packages for DKMS build, but also several useful tools.

Add a new variable `infiniband_mlnx_ofed_flavor` that allows to install a different package group.

See https://docs.nvidia.com/networking/display/mlnxofedv23102131lts/installing+mlnx_ofed#src-2650705989_InstallingMLNX_OFED-additionalinstallationprocedures for more details about these packages.