### PR TITLE
fix: Install MLNX_OFED flavors in separate tasks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,6 +51,7 @@ infiniband_mlnx_ofed_flavor: 'basic'
 # such cases, the parameters below can be set to False in the host inventory.
 infiniband_configure_repos: True
 infiniband_install_kernel_modules: True
+infiniband_install_mlnx_ofed: True
 
 # Configure Mellanox HCAs
 # The pci_bus must match the value in /sys/bus/pci/devices/

--- a/tasks/install-kernel-modules-Debian.yml
+++ b/tasks/install-kernel-modules-Debian.yml
@@ -1,8 +1,9 @@
 ---
-- name: Install MLNX_OFED packages for Debian OS family
+- name: Install MLNX_OFED kernel packages for Debian OS family
   ansible.builtin.package:
     name:
-      - "mlnx-ofed-{{ infiniband_mlnx_ofed_flavor }}"
+      - mlnx-ofed-kernel-dkms
+      - mlnx-ofed-kernel-utils
       - "{{ infiniband_kernel_headers_package }}-{{ ansible_facts['kernel'] }}"
     state: "{{ 'latest' if infiniband_upgrade else 'present' }}"
   register: packages_install

--- a/tasks/install-kernel-modules-RedHat.yml
+++ b/tasks/install-kernel-modules-RedHat.yml
@@ -1,0 +1,8 @@
+---
+- name: Install MLNX_OFED kernel packages for Red Hat OS family
+  ansible.builtin.package:
+    name:
+      - mlnx-ofa_kernel-devel
+      - kmod-mlnx-ofa_kernel
+    state: "{{ 'latest' if infiniband_upgrade else 'present' }}"
+  notify: "Ensure openibd.service is started"

--- a/tasks/install-mlnx-ofed.yml
+++ b/tasks/install-mlnx-ofed.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install MLNX_OFED packages for Red Hat OS family
+- name: Install MLNX_OFED packages
   ansible.builtin.package:
     name:
       - "mlnx-ofed-{{ infiniband_mlnx_ofed_flavor }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,10 +4,15 @@
     file: "repositories-{{ ansible_facts['os_family'] }}.yml"
   when: infiniband_configure_repos
 
+- name: Install MLNX_OFED
+  ansible.builtin.include_tasks:
+    file: "install-mlnx-ofed.yml"
+  when: infiniband_install_mlnx_ofed | bool
+
 - name: Install MLNX_OFED kernel modules
   ansible.builtin.include_tasks:
-    file: "install-{{ ansible_facts['os_family'] }}.yml"
-  when: infiniband_install_kernel_modules
+    file: "install-kernel-modules-{{ ansible_facts['os_family'] }}.yml"
+  when: infiniband_install_kernel_modules | bool
 
 - name: Install common InfiniBand packages
   ansible.builtin.package:


### PR DESCRIPTION
Some systems might need the MLNX_OFED kernel modules but can't install the MLNX_OFED user tools. Continue to install MLNX_OFED flavors, but add a variable `infiniband_install_mlnx_ofed` that can be set to false to skip this package.