### PR TITLE
feat: Add postinst script to install mlnx ofed with new kernel version

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ This is also true when using the kernel modules from the distro.
     infiniband_configure_repos: True
     infiniband_install_kernel_modules: True
 
+### Kernel upgrade
+
+Build mlnx-ofed-kernel modules with DKMS during kernel header post-installation, before any other modules.
+By default, this build process is triggered only during a kernel upgrade. 
+Therefore, the variable governing this operation is typically false by default
+    infiniband_dkms_postinst: False
+
 ### IPoIB
 
 Define the list of interfaces to configure with IPoIB. Each item of the list

--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ This is also true when using the kernel modules from the distro.
 
 ### Kernel upgrade
 
-Build mlnx-ofed-kernel modules with DKMS during kernel header post-installation, before any other modules.
-By default, this build process is triggered only during a kernel upgrade. 
-Therefore, the variable governing this operation is typically false by default
+Build mlnx-ofed-kernel modules with DKMS during kernel header post-installation,
+before any other modules.By default, this build process is triggered only during
+a kernel upgrade.Therefore, the variable governing this operation is typically
+false by default
     infiniband_dkms_postinst: False
 
 ### IPoIB

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ This is also true when using the kernel modules from the distro.
 ### Kernel upgrade
 
 Build mlnx-ofed-kernel modules with DKMS during kernel header post-installation,
-before any other modules.By default, this build process is triggered only during
-a kernel upgrade.Therefore, the variable governing this operation is typically
-false by default
+before any other modules.This build process is triggered during a kernel upgrade.
+The variable defaults to false.
+
     infiniband_dkms_postinst: False
 
 ### IPoIB

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,7 +52,9 @@ infiniband_mlnx_ofed_flavor: 'basic'
 infiniband_configure_repos: True
 infiniband_install_kernel_modules: True
 infiniband_install_mlnx_ofed: True
-infiniband_update_mlnx_ofed: False
+# Ensure the mlnx-ofed-kernel kernel modules are built with DKMS
+# immediately following the kernel headers post-installation, and prior to any other modules.
+infiniband_dkms_postinst: False
 # Configure Mellanox HCAs
 # The pci_bus must match the value in /sys/bus/pci/devices/
 # e.g. /sys/bus/pci/devices/0000:41:00.0/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,6 +56,7 @@ infiniband_install_mlnx_ofed: True
 # following the kernel headers post-installation, and prior to any other
 # modules.
 infiniband_dkms_postinst: False
+
 # Configure Mellanox HCAs
 # The pci_bus must match the value in /sys/bus/pci/devices/
 # e.g. /sys/bus/pci/devices/0000:41:00.0/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,8 +52,9 @@ infiniband_mlnx_ofed_flavor: 'basic'
 infiniband_configure_repos: True
 infiniband_install_kernel_modules: True
 infiniband_install_mlnx_ofed: True
-# Ensure the mlnx-ofed-kernel kernel modules are built with DKMS
-# immediately following the kernel headers post-installation, and prior to any other modules.
+# Ensure the mlnx-ofed-kernel kernel modules are built with DKMS immediately
+# following the kernel headers post-installation, and prior to any other
+# modules.
 infiniband_dkms_postinst: False
 # Configure Mellanox HCAs
 # The pci_bus must match the value in /sys/bus/pci/devices/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,7 +52,7 @@ infiniband_mlnx_ofed_flavor: 'basic'
 infiniband_configure_repos: True
 infiniband_install_kernel_modules: True
 infiniband_install_mlnx_ofed: True
-
+infiniband_update_mlnx_ofed: False
 # Configure Mellanox HCAs
 # The pci_bus must match the value in /sys/bus/pci/devices/
 # e.g. /sys/bus/pci/devices/0000:41:00.0/

--- a/tasks/dkms_postinst.yml
+++ b/tasks/dkms_postinst.yml
@@ -1,8 +1,8 @@
 ---
  - name: Add script content
    ansible.builtin.copy:
-     dest: /etc/kernel/header_postinst.d/mlnx-ofed-kernel
-     mode: 770
+     dest: /etc/kernel/header_postinst.d/01-dkms-mlnx-ofed-kernel
+     mode: 750
      content: |
        #!/bin/bash
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,7 +41,7 @@
     file: "configure-{{ ansible_facts['os_family'] }}.yml"
   when: infiniband_ipoib_interfaces is defined
 
-- name: Update MLNX_OFED kernel modules
+- name: Build mlnx-ofed-kernel modules
   ansible.builtin.include_tasks:
-    file: "update-mlnx-ofed.yml"
-  when: infiniband_update_mlnx_ofed | bool
+    file: "dkms_postinst.yml"
+  when: infiniband_dkms_postinst | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,3 +40,8 @@
   ansible.builtin.include_tasks:
     file: "configure-{{ ansible_facts['os_family'] }}.yml"
   when: infiniband_ipoib_interfaces is defined
+
+- name: Update MLNX_OFED kernel modules
+  ansible.builtin.include_tasks:
+    file: "update-mlnx-ofed.yml"
+  when: infiniband_update_mlnx_ofed | bool

--- a/tasks/update-mlnx-ofed.yml
+++ b/tasks/update-mlnx-ofed.yml
@@ -1,0 +1,19 @@
+---
+ - name: Add script content
+   ansible.builtin.copy:
+     dest: /etc/kernel/header_postinst.d/mlnx-ofed-kernel
+     mode: 770
+     content: |
+       #!/bin/bash
+
+       # We're passed the version of the kernel being installed
+       inst_kern=$1
+
+       uname_m=$(uname -m)
+
+       # Install mlnx-ofed-kernel first
+       for mod in $(dkms status mlnx-ofed-kernel | cut -d, -f1 | sort -u); do
+           /usr/sbin/dkms install ${mod} -k ${inst_kern}
+       done
+
+       /usr/bin/update-alternatives --set ofa_kernel_headers /usr/src/ofa_kernel/${uname_m}/${inst_kern}


### PR DESCRIPTION
Kernel modules reordering solution implemented.
MLNX_OFED is compiled with the new kernel version.
DKMS will compile the remaining modules based on the kernel version defined by MLNX_OFED.