### PR TITLE
Allows to install DOCA-OFED instead of the MLNX_OFED

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,6 +43,12 @@ infiniband_kernel_headers_package: 'linux-headers'
 # See NVIDIA MLNX_OFED documentation for a complete list of flavors.
 infiniband_mlnx_ofed_flavor: 'basic'
 
+# Transition from mlnx_ofed to doca_ofed
+infiniband_ofed_package: "mlnx-ofed-{{ infiniband_mlnx_ofed_flavor }}"
+infiniband_apt_pin_release: release o=MLNX_OFED
+# infiniband_ofed_package: "doca-ofed"
+# infiniband_apt_pin_release: release o=NVIDIA l=DOCA
+
 # Default to configure the repos and install the kernel modules.
 #
 # Some appliances like the NVIDIA DGX run their own software stack. When an

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,11 +43,13 @@ infiniband_kernel_headers_package: 'linux-headers'
 # See NVIDIA MLNX_OFED documentation for a complete list of flavors.
 infiniband_mlnx_ofed_flavor: 'basic'
 
-# Transition from mlnx_ofed to doca_ofed
+# MLNX OFED
 infiniband_ofed_package: "mlnx-ofed-{{ infiniband_mlnx_ofed_flavor }}"
 infiniband_apt_pin_release: release o=MLNX_OFED
+
+# DOCA OFED
 # infiniband_ofed_package: "doca-ofed"
-# infiniband_apt_pin_release: release o=NVIDIA l=DOCA
+# infiniband_apt_pin_release: release o=NVIDIA, l=DOCA
 
 # Default to configure the repos and install the kernel modules.
 #

--- a/tasks/install-mlnx-ofed.yml
+++ b/tasks/install-mlnx-ofed.yml
@@ -1,7 +1,7 @@
 ---
-- name: Install MLNX_OFED packages
+- name: Install OFED packages
   ansible.builtin.package:
     name:
-      - "mlnx-ofed-{{ infiniband_mlnx_ofed_flavor }}"
+      - "{{ infiniband_ofed_package }}"
     state: "{{ 'latest' if infiniband_upgrade else 'present' }}"
   notify: "Ensure openibd.service is started"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
     file: "repositories-{{ ansible_facts['os_family'] }}.yml"
   when: infiniband_configure_repos
 
-- name: Install MLNX_OFED
+- name: Install OFED
   ansible.builtin.include_tasks:
     file: "install-mlnx-ofed.yml"
   when: infiniband_install_mlnx_ofed | bool

--- a/tasks/repositories-Debian.yml
+++ b/tasks/repositories-Debian.yml
@@ -14,7 +14,7 @@
   ansible.builtin.copy:
     content: |
       Package: *
-      Pin: release o=MLNX_OFED
+      Pin: {{ infiniband_apt_pin_release }}
       Pin-Priority: {{ infiniband_apt_priority }}
     dest: /etc/apt/preferences.d/priority-infiniband
     mode: 0644


### PR DESCRIPTION
https://networking-docs.nvidia.com/doca/sdk/mlnx_ofed-to-doca-ofed-transition-guide